### PR TITLE
Use OAuth token type

### DIFF
--- a/managed_repository.go
+++ b/managed_repository.go
@@ -200,7 +200,7 @@ func (r *managedRepository) fetchUpstream() (err error) {
 			err = status.Errorf(codes.Internal, "cannot obtain an OAuth2 access token for the server: %v", err)
 			return err
 		}
-		err = runGit(op, r.localDiskPath, "-c", "http.extraHeader=Authorization: Bearer "+t.AccessToken, "fetch", "--progress", "-f", "-n", "origin", "refs/heads/*:refs/heads/*", "refs/changes/*:refs/changes/*")
+		err = runGit(op, r.localDiskPath, "-c", "http.extraHeader=Authorization: "+t.Type()+" "+t.AccessToken, "fetch", "--progress", "-f", "-n", "origin", "refs/heads/*:refs/heads/*", "refs/changes/*:refs/changes/*")
 	}
 	if err == nil {
 		t, err = r.config.TokenSource.Token()
@@ -208,7 +208,7 @@ func (r *managedRepository) fetchUpstream() (err error) {
 			err = status.Errorf(codes.Internal, "cannot obtain an OAuth2 access token for the server: %v", err)
 			return err
 		}
-		err = runGit(op, r.localDiskPath, "-c", "http.extraHeader=Authorization: Bearer "+t.AccessToken, "fetch", "--progress", "-f", "origin")
+		err = runGit(op, r.localDiskPath, "-c", "http.extraHeader=Authorization: "+t.Type()+" "+t.AccessToken, "fetch", "--progress", "-f", "origin")
 	}
 	logStats("fetch", startTime, err)
 	if err == nil {


### PR DESCRIPTION
Looking at using this to cache some Github Enterprise repos, and Github expects personal access tokens to be passed using basic auth instead of bearer. This PR respects the type passed in the token (will not affect existing users, as `Bearer` is the default).

Note that this already works for the `lsRefsUpstream` method because the token is applied using `SetAuthHeader`: https://github.com/google/goblet/blob/d246de9cd0cc826b3e5a5a07b7407d36e12f7e92/managed_repository.go#L142