### PR TITLE
Pass upstream URL to token generation

### DIFF
--- a/goblet-server/main.go
+++ b/goblet-server/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/google/uuid"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
 	logpb "google.golang.org/genproto/googleapis/logging/v2"
@@ -230,7 +231,9 @@ func main() {
 		LocalDiskCacheRoot:         *cacheRoot,
 		URLCanonializer:            googlehook.CanonicalizeURL,
 		RequestAuthorizer:          authorizer,
-		TokenSource:                ts,
+		TokenSource:                func(upstreamURL *url.URL) (*oauth2.Token, error) {
+			return ts.Token()
+		},
 		ErrorReporter:              er,
 		RequestLogger:              rl,
 		LongRunningOperationLogger: lrol,

--- a/goblet.go
+++ b/goblet.go
@@ -64,7 +64,7 @@ type ServerConfig struct {
 
 	RequestAuthorizer func(*http.Request) error
 
-	TokenSource oauth2.TokenSource
+	TokenSource func(upstreamURL *url.URL) (*oauth2.Token, error)
 
 	ErrorReporter func(*http.Request, error)
 

--- a/managed_repository.go
+++ b/managed_repository.go
@@ -132,7 +132,7 @@ func (r *managedRepository) lsRefsUpstream(command []*gitprotocolio.ProtocolV2Re
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "cannot construct a request object: %v", err)
 	}
-	t, err := r.config.TokenSource.Token()
+	t, err := r.config.TokenSource(r.upstreamURL)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "cannot obtain an OAuth2 access token for the server: %v", err)
 	}
@@ -195,7 +195,7 @@ func (r *managedRepository) fetchUpstream() (err error) {
 	defer r.mu.Unlock()
 	if splitGitFetch {
 		// Fetch heads and changes first.
-		t, err = r.config.TokenSource.Token()
+		t, err = r.config.TokenSource(r.upstreamURL)
 		if err != nil {
 			err = status.Errorf(codes.Internal, "cannot obtain an OAuth2 access token for the server: %v", err)
 			return err
@@ -203,7 +203,7 @@ func (r *managedRepository) fetchUpstream() (err error) {
 		err = runGit(op, r.localDiskPath, "-c", "http.extraHeader=Authorization: Bearer "+t.AccessToken, "fetch", "--progress", "-f", "-n", "origin", "refs/heads/*:refs/heads/*", "refs/changes/*:refs/changes/*")
 	}
 	if err == nil {
-		t, err = r.config.TokenSource.Token()
+		t, err = r.config.TokenSource(r.upstreamURL)
 		if err != nil {
 			err = status.Errorf(codes.Internal, "cannot obtain an OAuth2 access token for the server: %v", err)
 			return err


### PR DESCRIPTION
When Goblet is used across different repos or different organizations, it's useful to support custom token generation mechanisms for different upstreams. For example, a Github app's installation tokens need to be generated separately for each organization.

This PR modifies the `TokenSource` configuration option to a function that accepts the upstream URL as a parameter.